### PR TITLE
Clarify OAuth env variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 EXPO_PUBLIC_RORK_API_BASE_URL=http://localhost:3000
 
 # Google OAuth Configuration
-GOOGLE_CLIENT_ID=your_google_client_id
-GOOGLE_REDIRECT_URI=https://auth.expo.io/@your-username/fasthack
+EXPO_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
+EXPO_PUBLIC_GOOGLE_REDIRECT_URI=https://auth.expo.io/@your-username/fasthack

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ To use Google OAuth:
 4. Add the following authorized redirect URIs:
    - `https://auth.expo.io/@your-username/fasthack`
    - `fasthack://`
-5. Add your client ID and redirect URI to the `.env` file
+5. Add your client ID and redirect URI to the `.env` file as:
+   - `EXPO_PUBLIC_GOOGLE_CLIENT_ID`
+   - `EXPO_PUBLIC_GOOGLE_REDIRECT_URI`
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- show specific Google OAuth env variables in README
- update `.env.example` with `EXPO_PUBLIC_GOOGLE_CLIENT_ID` and `EXPO_PUBLIC_GOOGLE_REDIRECT_URI`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840389b8360832598aeae993e34784e