### PR TITLE
Fix tRPC transformer usage

### DIFF
--- a/lib/trpc.ts
+++ b/lib/trpc.ts
@@ -14,7 +14,7 @@ export const trpcClient = trpc.createClient({
   links: [
     httpLink({
       url: `${getBaseUrl()}/api/trpc`,
-      transformer: superjson,
     }),
   ],
+  transformer: superjson,
 });


### PR DESCRIPTION
## Summary
- configure `superjson` transformer at the tRPC client level instead of in the `httpLink`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'zustand'...)*

------
https://chatgpt.com/codex/tasks/task_e_684033a7d1f083259e22b5bbc466eb95